### PR TITLE
Change in simulate from items

### DIFF
--- a/R/connect_to_formr.R
+++ b/R/connect_to_formr.R
@@ -604,8 +604,7 @@ formr_simulate_from_items = function(item_list, n = 300) {
       if (length(limits) == 3) {
       	by = limits[3]
         sample_from = seq(from = limits[1], to = limits[2], 
-          by = by, 
-          ifelse( by > 0, -1 * by, by))
+          by = ifelse( by < 0, -1 * by, by))
 
         sim[, item$name] = sample(sample_from, size = n, 
           replace = T)


### PR DESCRIPTION
I was not able to simulate data from an items object. I am not a 100% sure that my fix is entirely correct but it seems that the ifelse statement was unintentionally filling out the length.out argument in stead of the by argument (and that the greater than sign should have been a less than sign). By tracing the function with this alteration i was able to run the function with no problems. 

It could be that the length.out argument needs to be filled in with a non-negative number in certain cases, but as the function is now it will define both the by argument and the length.out - this is too many arguments for seq. 

Let me know if i have completely misunderstood the purpose of the ifelse clause and i should look closer for a proper fix :) 