### PR TITLE
recomend more lightwight install mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,5 @@ https://rubenarslan.github.io/formr
 
 If you want to install the R package locally (e.g. to connect to formr and fetch the data in a nice format for you), run:
 
-    install.packages("devtools")
-    devtools::install_github("rubenarslan/formr")
+    install.packages("remotes")
+    remotes::install_github("rubenarslan/formr")


### PR DESCRIPTION
From the remotes description:

> This package is a lightweight replacement of the `install_*` functions in [`devtools`](https://github.com/r-lib/devtools). Indeed most of the code was copied over from `devtools`.