### PR TITLE
Add \value to dot-formr.Rd (CRAN second-review fix)

### DIFF
--- a/R/shorthands.R
+++ b/R/shorthands.R
@@ -216,6 +216,12 @@ escapeRegex = function(string)
 #' session the environment is empty.
 #'
 #' @format An environment.
+#' @return An [environment] holding per-request state in its bindings (the
+#'   `run_name`, `host`, `access_token`, `last_action_time` and
+#'   `last_action_date` fields listed above). `.formr` is a data object, not a
+#'   function, so it does not itself return a value; the rforms.org server
+#'   populates these bindings before user code runs and the environment is empty
+#'   outside a formr/OpenCPU session.
 #' @export
 .formr <- new.env()
 .formr$last_action_time <- NULL

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,15 +1,23 @@
 ## Resubmission
 
-This is a resubmission. Thank you for the review of 1.0.0. We have addressed
-every point raised:
+This is a resubmission. Thank you for the further review. The previous
+resubmission still left one missing `\value` tag, which is now fixed:
 
-* **Missing `\value` in .Rd files.** Every exported function and method now has
-  a `\value` (roxygen `@return`) tag describing the class/structure of the
-  result and what it means. Functions called only for their side effects say so
+* **Missing `\value` in `dot-formr.Rd`.** The exported `.formr` environment now
+  has a `\value` tag describing it (an environment holding per-request state in
+  its bindings), in addition to its `\format`. Every other exported function,
+  method and object already carries a `\value` describing the class/structure of
+  the result and what it means; functions called only for their side effects say
+  so explicitly. The only remaining `\value`-free topic is `reexports.Rd`, which
+  uses `\docType{import}` (re-exported objects from other packages).
+
+The original 1.0.0 review points remain addressed:
+
+* **Missing `\value` in .Rd files.** Every exported function and method has a
+  `\value` (roxygen `@return`) tag describing the class/structure of the result
+  and what it means. Functions called only for their side effects say so
   explicitly (e.g. "No return value, called for side effects" / "Invisibly
-  `TRUE`; called for its side effect of ..."). (Re-exported objects in
-  `reexports.Rd` use `\docType{import}` and the exported environment `.formr`
-  uses `\format`, neither of which takes `\value`.)
+  `TRUE`; called for its side effect of ...").
 
 * **Vignettes did not execute code.** All eight vignettes now run code. API
   calls are replayed offline from pre-recorded `vcr` cassettes shipped in

--- a/man/dot-formr.Rd
+++ b/man/dot-formr.Rd
@@ -9,6 +9,14 @@ An environment.
 \usage{
 .formr
 }
+\value{
+An \link{environment} holding per-request state in its bindings (the
+\code{run_name}, \code{host}, \code{access_token}, \code{last_action_time} and
+\code{last_action_date} fields listed above). \code{.formr} is a data object, not a
+function, so it does not itself return a value; the rforms.org server
+populates these bindings before user code runs and the environment is empty
+outside a formr/OpenCPU session.
+}
 \description{
 An environment that the rforms.org server fills with per-request state
 when R code runs inside an OpenCPU session on a formr study (for


### PR DESCRIPTION
CRAN's second review flagged one remaining missing tag:

```
Missing Rd-tags:
      dot-formr.Rd: \value
```

The exported `.formr` environment had `\format` but no `\value`. This adds an `@return` describing it — an environment that the rforms.org server populates with per-request state (`run_name`, `host`, `access_token`, `last_action_time`, `last_action_date`) and which is empty outside a formr/OpenCPU session.

Verified every other exported topic already carries `\value`; the only remaining `\value`-free Rd is `reexports.Rd` (`\docType{import}`), which is exempt. `cran-comments.md` updated for the resubmission.

`devtools::check()`: **0 errors | 0 warnings | 1 note** (the benign offline "unable to verify current time").

🤖 Generated with [Claude Code](https://claude.com/claude-code)