### PR TITLE
Fix #45: always treat calculate items as strings (v1.1.1)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Description: Serves as a companion toolkit for the 'formr' survey
     assets (surveys, CSS) for local editing; and functions for use
     within 'formr' runs to generate dynamic, personalized feedback
     plots and to simplify survey logic.
-Version: 1.1.0
+Version: 1.1.1
 Authors@R: c(
     person("Ruben", "Arslan",
         email = "rubenarslan@gmail.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# formr 1.1.1
+
+* `formr_api_results()` (via `formr_api_recognise()`) no longer corrupts
+  `calculate` items. They are now **always returned as strings**: a `calculate`
+  item can legitimately hold non-numeric text — e.g. a CSV blob read from a file
+  that merely *starts* with a number, like `"6136,63,50,woman,man"` — which the
+  old code force-coerced with `as.numeric()`, silently turning every row into
+  `NA`. `number`/`range` items remain numeric but are now coerced only when
+  lossless (<https://github.com/rubenarslan/formr/issues/45>).
+
 # formr 1.1.0
 
 * **CRAN resubmission fixes (addressing the 1.0.0 review):**

--- a/R/api_results.R
+++ b/R/api_results.R
@@ -306,8 +306,16 @@ formr_api_recognise <- function(item_list, results) {
 		# Explicit Types for non-choice items
 		else if (type %in% c("date", "datetime")) {
 			results[[name]] <- tryCatch(as.POSIXct(results[[name]]), error = function(e) results[[name]])
-		} else if (type %in% c("number", "range", "calculate")) {
-			results[[name]] <- suppressWarnings(as.numeric(results[[name]]))
+		} else if (type == "calculate") {
+			# `calculate` items can hold arbitrary text (e.g. a CSV blob read
+			# from a file that merely starts with a number). They are NEVER
+			# numeric -- the old as.numeric() silently turned such values into
+			# NA in every row. Always keep them as strings. See issue #45.
+			results[[name]] <- as.character(results[[name]])
+		} else if (type %in% c("number", "range")) {
+			# number/range are UI-constrained numeric; coerce only when lossless
+			# so a stray non-numeric value can never silently nuke the column.
+			results[[name]] <- .lossless_as_numeric(results[[name]])
 		}
 		
 		# APPLY LABEL TO FINAL VECTOR
@@ -460,6 +468,25 @@ formr_api_aggregate <- function(results, item_list, min_items = 2) {
 		results <- .log_action(results, "Scale", sprintf("Computed %d scales (means)", scales_created))
 	}
 	results
+}
+
+#' Helper: Coerce to numeric only when lossless
+#'
+#' Returns `as.numeric(x)` only if the conversion introduces no new missings
+#' among values that were non-empty to begin with. Otherwise the input is
+#' returned untouched, so a stray non-numeric value can never silently flatten
+#' a `number`/`range` column to all-NA.
+#' @noRd
+.lossless_as_numeric <- function(x) {
+	if (is.numeric(x)) return(x)
+	chr <- as.character(x)
+	not_missing <- !is.na(chr) & nzchar(trimws(chr))
+	converted <- suppressWarnings(as.numeric(chr))
+	# A value that was present but no longer parses means coercion lost data.
+	if (any(not_missing & is.na(converted))) {
+		return(x)
+	}
+	converted
 }
 
 #' Helper: Join results safely

--- a/tests/testthat/test-api_results.R
+++ b/tests/testthat/test-api_results.R
@@ -35,3 +35,52 @@ test_that("formr_api_fetch_results picks up .formr$run_name when set", {
 	formr_api_fetch_results()
 	expect_match(captured, "runs/scoped-run/results", fixed = TRUE)
 })
+
+# Regression: a `calculate` item can legitimately store strings (e.g. a CSV
+# blob read from a file that merely starts with a number). formr_api_recognise
+# used to force every "numeric" item through as.numeric(), silently turning
+# such columns into all-NA. See https://github.com/rubenarslan/formr/issues/45
+test_that("formr_api_recognise keeps string-valued calculate items intact", {
+	item_list <- dplyr::tibble(
+		name = "mycalc", type = "calculate",
+		label = "External CSV blob", choices = list(NULL)
+	)
+	df <- dplyr::tibble(
+		session = c("a", "b"),
+		mycalc = c("6136,63,50,woman,man,friendship", "1234,99,40,man,woman,romance")
+	)
+
+	out <- formr_api_recognise(item_list, df)
+
+	expect_type(out$mycalc, "character")
+	expect_identical(as.vector(out$mycalc), df$mycalc)
+	expect_false(any(is.na(out$mycalc)))
+})
+
+test_that("formr_api_recognise keeps calculate items as strings even when numeric-looking", {
+	item_list <- dplyr::tibble(
+		name = "mycalc", type = "calculate",
+		label = "A number-like blob", choices = list(NULL)
+	)
+	df <- dplyr::tibble(session = c("a", "b", "c"), mycalc = c("3.5", "7", "12"))
+
+	out <- formr_api_recognise(item_list, df)
+
+	# calculate is NEVER coerced to numeric, even when every value looks numeric
+	expect_type(out$mycalc, "character")
+	expect_identical(as.vector(out$mycalc), c("3.5", "7", "12"))
+})
+
+test_that("formr_api_recognise leaves number/range items numeric", {
+	item_list <- dplyr::tibble(
+		name = c("age", "slider"), type = c("number", "range"),
+		label = c("Age", "Slider"), choices = list(NULL, NULL)
+	)
+	df <- dplyr::tibble(session = c("a", "b"), age = c("25", "40"), slider = c("1", "7"))
+
+	out <- formr_api_recognise(item_list, df)
+
+	expect_type(out$age, "double")
+	expect_type(out$slider, "double")
+	expect_equal(as.vector(out$age), c(25, 40))
+})


### PR DESCRIPTION
## Problem

`formr_api_results()` (via `formr_api_recognise()`) force-coerced every `number`/`range`/`calculate` item through `as.numeric()`. A `calculate` item can legitimately hold non-numeric text — e.g. a CSV blob read from a file that merely *starts* with a number, like `"6136,63,50,woman,man,friendship"`. `as.numeric()` on that returns `NA`, and because the warning was suppressed, the **entire column became `NA` in every row**.

## Fix

- **`calculate` items are now always returned as strings** — never coerced to numeric, even when every value happens to look numeric.
- `number`/`range` items remain numeric but are coerced only when **lossless** (new `.lossless_as_numeric()` helper), so a stray non-numeric value can't silently nuke those columns either.

## Tests

Adds regression tests in `test-api_results.R` (string-valued calculate, numeric-looking calculate stays string, number/range stay numeric). Full suite: 223 passed, 0 failed.

Bumps version to 1.1.1 with a NEWS entry.

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)