### PR TITLE
Hotfix v1.1.2: restore knit.html output in working directory

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Description: Serves as a companion toolkit for the 'formr' survey
     assets (surveys, CSS) for local editing; and functions for use
     within 'formr' runs to generate dynamic, personalized feedback
     plots and to simplify survey logic.
-Version: 1.1.1
+Version: 1.1.2
 Authors@R: c(
     person("Ruben", "Arslan",
         email = "rubenarslan@gmail.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# formr 1.1.2
+
+* Hotfix: `formr_render()` and `formr_inline_render()` again write their output
+  to a file named `knit.html` in the working directory. In 1.1.1 the CRAN review
+  changes routed rendering through `tempdir()` with a random filename, which
+  broke rforms.org/OpenCPU — the server serves the rendered page via
+  `getFiles("knit.html")` and so could no longer find it. If you are on 1.1.1,
+  upgrade to 1.1.2 (or pin to 1.1.0).
+
 # formr 1.1.1
 
 * `formr_api_results()` (via `formr_api_recognise()`) no longer corrupts

--- a/R/rmarkdown_options.R
+++ b/R/rmarkdown_options.R
@@ -119,7 +119,7 @@ render_text = function(text, ...) {
 
 formr_inline_render = function(text, self_contained = TRUE, ...) {
   fileName = rmarkdown::render(input = write_to_file(text,
-    ext = ".Rmd"), output_format = formr::markdown_hard_line_breaks(self_contained = self_contained,
+    name = "knit", ext = ".Rmd"), output_format = formr::markdown_hard_line_breaks(self_contained = self_contained,
     fragment.only = TRUE, section_divs = FALSE), ...)
   readChar(fileName, file.info(fileName)$size)
 }
@@ -179,7 +179,7 @@ formr_render_commonmark = function(text) {
 
 formr_render = function(text, self_contained = FALSE, ...) {
   fileName = rmarkdown::render(input = write_to_file(text,
-    ext = ".Rmd"), output_format = formr::markdown_hard_line_breaks(self_contained = self_contained,
+    name = "knit", ext = ".Rmd"), output_format = formr::markdown_hard_line_breaks(self_contained = self_contained,
     fragment.only = FALSE), clean = TRUE, quiet = TRUE, ...)
   fileName
 }
@@ -190,8 +190,12 @@ write_to_file <- function(..., name = NULL, ext = ".Rmd") {
   if (is.null(name)) {
     filename <- paste0(tempfile(), ext)
   } else {
-    # keep writes inside the session tempdir (never the working directory)
-    filename = file.path(tempdir(), paste0(basename(name), ext))
+    # A named write lands in the working directory on purpose: formr_render()
+    # passes name = "knit" so rmarkdown produces "knit.html" there, which is
+    # the file rforms.org/OpenCPU serves via getFiles("knit.html"). Moving this
+    # into tempdir() (v1.1.1) broke that lookup in production -- see issue #45's
+    # follow-up; do not "fix" it back to tempdir without updating the PHP side.
+    filename = paste0(name, ext)
   }
   mytext <- eval(...)
   write(mytext, filename)

--- a/tests/testthat/test-rmarkdown_options.R
+++ b/tests/testthat/test-rmarkdown_options.R
@@ -14,6 +14,25 @@ test_that("formr_render_commonmark works correctly", {
   expect_match(result, "<em>italic</em>")
 })
 
+# Regression: rforms.org/OpenCPU serves the rendered page via
+# getFiles("knit.html"), so formr_render() must emit a file literally named
+# "knit.html" in the working directory. v1.1.1 moved this into tempdir() with a
+# random name and broke production rendering; this guards against a recurrence.
+test_that("formr_render writes knit.html to the working directory", {
+  skip_if_not_installed("rmarkdown")
+
+  wd <- file.path(tempdir(), "formr_render_wd")
+  dir.create(wd, showWarnings = FALSE)
+  old <- setwd(wd)
+  on.exit({ setwd(old); unlink(c("knit.Rmd", "knit.html", "knit_files"), recursive = TRUE) }, add = TRUE)
+  unlink(c("knit.Rmd", "knit.html"))
+
+  out <- formr_render("# Hi\n\nThere are `r 1 + 1` types.")
+
+  expect_identical(basename(out), "knit.html")
+  expect_true(file.exists(file.path(wd, "knit.html")))
+})
+
 test_that("paste.knit_asis works correctly", {
   # Test with example from documentation
   result <- paste.knit_asis("# Headline 1", "## Headline 2")


### PR DESCRIPTION
## Production regression (v1.1.1)

The CRAN-review changes in **v1.1.1** routed `formr_render()` and `formr_inline_render()` through `tempdir()` with a random output filename. But rforms.org/OpenCPU serves the rendered page via `getFiles("knit.html")` (see `Functions.php`, `Page.php`, `NoteIframe.php`, `RunUnit.php` in formr.org), so the server could no longer find the rendered output — breaking page, feedback and inline rendering in production.

`v1.1.0` was the last good release; `v1.1.1` is the only released version with the bug.

## Fix

- `formr_render()` and `formr_inline_render()` pass `name = "knit"` again.
- `write_to_file()`'s *named* branch writes to the **working directory** again (the unnamed branch still uses `tempfile()`), so rmarkdown emits `knit.html` exactly where the PHP side looks for it.
- The `@return` documentation added in v1.1.1 is preserved; only the behavioural changes are reverted.

## Tests

Adds a regression test asserting `formr_render()` produces a file literally named `knit.html` in the working directory. Full suite: 225 passed, 0 failed.

Bumps version to 1.1.2 with a NEWS entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)