### PR TITLE
v1.1.3: OpenCPU-aware formr_render write directory + WASM-installable dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,8 +37,6 @@ Imports:
     jsonlite,
     lubridate,
     rmarkdown,
-    otp,
-    keyring,
     purrr,
     readr,
     rlang
@@ -49,7 +47,9 @@ Suggests:
     withr,
     rstudioapi,
     plotly,
-    commonmark
+    commonmark,
+    keyring,
+    otp
 License: MIT + file LICENSE
 LazyData: true
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Description: Serves as a companion toolkit for the 'formr' survey
     assets (surveys, CSS) for local editing; and functions for use
     within 'formr' runs to generate dynamic, personalized feedback
     plots and to simplify survey logic.
-Version: 1.1.3
+Version: 1.2.0
 Authors@R: c(
     person("Ruben", "Arslan",
         email = "rubenarslan@gmail.com",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,7 @@ Imports:
     rmarkdown,
     purrr,
     readr,
-    rlang
+    rlang (>= 1.0.0)
 Suggests:
     testthat (>= 3.0.0),
     vcr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Description: Serves as a companion toolkit for the 'formr' survey
     assets (surveys, CSS) for local editing; and functions for use
     within 'formr' runs to generate dynamic, personalized feedback
     plots and to simplify survey logic.
-Version: 1.1.2
+Version: 1.1.3
 Authors@R: c(
     person("Ruben", "Arslan",
         email = "rubenarslan@gmail.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 # formr 1.1.3
 
+* `keyring` and `otp` moved from Imports to Suggests so that formr can be
+  installed on WebAssembly/webR (`keyring` needs a system credential store and
+  has no wasm build; all remaining hard dependencies are available as wasm
+  binaries). Both packages are only needed for the credential-storage
+  convenience path: `formr_store_keys()` and `formr_connect(keyring = ...)`
+  now error with an installation hint when `keyring` is missing, and
+  `formr_connect()` falls back to prompting for the 2FA code when `otp` is
+  missing. If you use these features, `install.packages(c("keyring", "otp"))`
+  once — nothing else changes.
+
 * `formr_render()` and `formr_inline_render()` now pick their write directory
   automatically, reconciling the rforms.org/OpenCPU integration with CRAN
   policy. Inside an OpenCPU/formr session — detected because the `opencpu`

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# formr 1.1.3
+# formr 1.2.0
 
 * `keyring` and `otp` moved from Imports to Suggests so that formr can be
   installed on WebAssembly/webR (`keyring` needs a system credential store and

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,11 +4,13 @@
   installed on WebAssembly/webR (`keyring` needs a system credential store and
   has no wasm build; all remaining hard dependencies are available as wasm
   binaries). Both packages are only needed for the credential-storage
-  convenience path: `formr_store_keys()` and `formr_connect(keyring = ...)`
-  now error with an installation hint when `keyring` is missing, and
-  `formr_connect()` falls back to prompting for the 2FA code when `otp` is
-  missing. If you use these features, `install.packages(c("keyring", "otp"))`
-  once — nothing else changes.
+  convenience path. Functions that need a suggested package
+  (`formr_store_keys()`, `formr_connect(keyring = ...)`,
+  `formr_overview_sankey()`, `formr_render_commonmark()`) now check for it
+  via `rlang::check_installed()`: in interactive sessions you are offered to
+  install the package on first use, otherwise they error with an informative
+  message. `formr_connect()` falls back to prompting for the 2FA code
+  manually when `otp` is unavailable.
 
 * `formr_render()` and `formr_inline_render()` now pick their write directory
   automatically, reconciling the rforms.org/OpenCPU integration with CRAN

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,17 @@
+# formr 1.1.3
+
+* `formr_render()` and `formr_inline_render()` now pick their write directory
+  automatically, reconciling the rforms.org/OpenCPU integration with CRAN
+  policy. Inside an OpenCPU/formr session — detected because the `opencpu`
+  namespace is loaded on the server, or because rforms.org populated the
+  per-request `.formr` environment — they keep writing `knit.Rmd`/`knit.html`
+  to the (ephemeral, per-request) working directory that the server reads via
+  `getFiles("knit.html")`, exactly as in 1.1.2. In ordinary R sessions they
+  write to `tempdir()` instead, as in 1.1.1, so the package no longer touches
+  the user's working directory by default. Override the detection with
+  `options(formr.in_opencpu = TRUE/FALSE)` or pass the new `dir` argument
+  explicitly.
+
 # formr 1.1.2
 
 * Hotfix: `formr_render()` and `formr_inline_render()` again write their output

--- a/R/api_overview.R
+++ b/R/api_overview.R
@@ -118,10 +118,8 @@ formr_overview_sankey <- function(run_name = .formr$run_name,
 	idx   <- setNames(seq_along(nodes) - 1L, nodes)
 	n_real <- length(unique(steps$session))
 
-	if (!requireNamespace("plotly", quietly = TRUE)) {
-		stop("formr_overview_sankey() needs the 'plotly' package. ",
-		     "Install it with install.packages(\"plotly\").")
-	}
+	rlang::check_installed("plotly",
+		reason = "to draw the sankey diagram in formr_overview_sankey().")
 
 	plot <- plotly::plot_ly(
 		type = "sankey",

--- a/R/connect_to_formr.R
+++ b/R/connect_to_formr.R
@@ -10,7 +10,11 @@ if (getRversion() >= "2.15.1")  utils::globalVariables(c(".")) # allow dplyr, ma
 #' @param email your registered email address
 #' @param password your password
 #' @param host defaults to [formr_last_host()], which defaults to https://rforms.org
-#' @param keyring a shorthand for the account you're using
+#' @param keyring a shorthand for the account you're using. Requires the
+#'   suggested `keyring` package; generating a 2FA code from a stored secret
+#'   additionally requires the suggested `otp` package. Both are optional so
+#'   that the package stays installable on platforms without a system
+#'   credential store (e.g. WebAssembly/webR).
 #' @return Invisibly `TRUE` on success; called for its side effect of establishing
 #'   an authenticated cookie session with the formr server (stored in httr's cookie jar).
 #' @export
@@ -22,7 +26,11 @@ if (getRversion() >= "2.15.1")  utils::globalVariables(c(".")) # allow dplyr, ma
 formr_connect <- function(email = NULL, password = NULL, host = formr_last_host(), keyring = NULL) {
 	formr_last_host(host)  # Store the host
 	if (!missing(keyring) && !is.null(keyring)) {
-		if (is.null(email) && 
+		if (!requireNamespace("keyring", quietly = TRUE)) {
+			stop("formr_connect(keyring = ...) needs the 'keyring' package. ",
+					 "Install it with install.packages(\"keyring\") or pass email and password directly.")
+		}
+		if (is.null(email) &&
 				length(keyring::key_list(keyring)[["username"]]) %in% 1:2) {
 			usernames <- keyring::key_list(keyring)[["username"]]
 			email <- usernames[!grepl(" 2FA", usernames)][[1]]
@@ -51,7 +59,13 @@ formr_connect <- function(email = NULL, password = NULL, host = formr_last_host(
 		}
 		
 		if (!is.null(twofa_secret) && twofa_secret != "") {
-			code <- otp::TOTP$new(twofa_secret)$now()
+			if (requireNamespace("otp", quietly = TRUE)) {
+				code <- otp::TOTP$new(twofa_secret)$now()
+			} else {
+				message("The 'otp' package is not installed, so the 2FA code cannot be ",
+								"generated from the stored secret. Install it with install.packages(\"otp\").")
+				code <- readline("Enter 2FA code: ")
+			}
 		} else {
 			code <- readline("Enter 2FA code: ")
 		}

--- a/R/connect_to_formr.R
+++ b/R/connect_to_formr.R
@@ -14,7 +14,8 @@ if (getRversion() >= "2.15.1")  utils::globalVariables(c(".")) # allow dplyr, ma
 #'   suggested `keyring` package; generating a 2FA code from a stored secret
 #'   additionally requires the suggested `otp` package. Both are optional so
 #'   that the package stays installable on platforms without a system
-#'   credential store (e.g. WebAssembly/webR).
+#'   credential store (e.g. WebAssembly/webR); in interactive sessions you
+#'   will be offered to install them the first time they are needed.
 #' @return Invisibly `TRUE` on success; called for its side effect of establishing
 #'   an authenticated cookie session with the formr server (stored in httr's cookie jar).
 #' @export
@@ -26,10 +27,10 @@ if (getRversion() >= "2.15.1")  utils::globalVariables(c(".")) # allow dplyr, ma
 formr_connect <- function(email = NULL, password = NULL, host = formr_last_host(), keyring = NULL) {
 	formr_last_host(host)  # Store the host
 	if (!missing(keyring) && !is.null(keyring)) {
-		if (!requireNamespace("keyring", quietly = TRUE)) {
-			stop("formr_connect(keyring = ...) needs the 'keyring' package. ",
-					 "Install it with install.packages(\"keyring\") or pass email and password directly.")
-		}
+		# Offers to install keyring on first use in interactive sessions;
+		# errors with an informative message otherwise.
+		rlang::check_installed("keyring",
+			reason = "to look up the credentials referenced by `keyring =`.")
 		if (is.null(email) &&
 				length(keyring::key_list(keyring)[["username"]]) %in% 1:2) {
 			usernames <- keyring::key_list(keyring)[["username"]]
@@ -59,11 +60,17 @@ formr_connect <- function(email = NULL, password = NULL, host = formr_last_host(
 		}
 		
 		if (!is.null(twofa_secret) && twofa_secret != "") {
+			# Offer to install otp on first use (interactive prompt). Unlike the
+			# keyring check above this must not abort: if the user declines or the
+			# session is non-interactive, they can still type the code manually.
+			try(rlang::check_installed("otp",
+					reason = "to generate the 2FA code from your stored secret."),
+				silent = TRUE)
 			if (requireNamespace("otp", quietly = TRUE)) {
 				code <- otp::TOTP$new(twofa_secret)$now()
 			} else {
-				message("The 'otp' package is not installed, so the 2FA code cannot be ",
-								"generated from the stored secret. Install it with install.packages(\"otp\").")
+				message("Without the 'otp' package the 2FA code cannot be generated ",
+								"from the stored secret; please enter it manually.")
 				code <- readline("Enter 2FA code: ")
 			}
 		} else {

--- a/R/rmarkdown_options.R
+++ b/R/rmarkdown_options.R
@@ -155,10 +155,8 @@ formr_knit = function(text) {
 #' formr_render_commonmark("There are only `r sample(2:3, 1)` types of people.")
 
 formr_render_commonmark = function(text) {
-	if (!requireNamespace("commonmark", quietly = TRUE)) {
-		stop("formr_render_commonmark() needs the 'commonmark' package. ",
-		     "Install it with install.packages(\"commonmark\").")
-	}
+	rlang::check_installed("commonmark",
+		reason = "to render CommonMark markdown in formr_render_commonmark().")
 	commonmark::markdown_html(text =
 															knitr::knit(text = text, 
 																					quiet = TRUE, 

--- a/R/rmarkdown_options.R
+++ b/R/rmarkdown_options.R
@@ -112,14 +112,18 @@ render_text = function(text, ...) {
 #'
 #' @param text that will be written to a tmp file and used as the input argument
 #' @param self_contained passed to \link{markdown_custom_options}
+#' @param dir directory in which the intermediate `knit.Rmd` and the rendered
+#'   `knit.html` are written. Defaults to the working directory inside an
+#'   OpenCPU/formr session and to [tempdir()] in ordinary R sessions; see
+#'   [formr_render()] for details.
 #' @param ... all other arguments passed to [rmarkdown::render()]
-#' 
+#'
 #' @return A length-1 character string of rendered inline HTML.
 #' @export
 
-formr_inline_render = function(text, self_contained = TRUE, ...) {
+formr_inline_render = function(text, self_contained = TRUE, dir = NULL, ...) {
   fileName = rmarkdown::render(input = write_to_file(text,
-    name = "knit", ext = ".Rmd"), output_format = formr::markdown_hard_line_breaks(self_contained = self_contained,
+    name = "knit", ext = ".Rmd", dir = dir), output_format = formr::markdown_hard_line_breaks(self_contained = self_contained,
     fragment.only = TRUE, section_divs = FALSE), ...)
   readChar(fileName, file.info(fileName)$size)
 }
@@ -172,30 +176,68 @@ formr_render_commonmark = function(text) {
 #'
 #' @param text that will be written to a tmp file and used as the input argument
 #' @param self_contained passed to \link{markdown_custom_options}
+#' @param dir directory in which the intermediate `knit.Rmd` and the rendered
+#'   `knit.html` are written. Defaults to the working directory when the code
+#'   runs inside an OpenCPU/formr session (there, the working directory is the
+#'   ephemeral per-request session directory from which rforms.org retrieves
+#'   the rendered page via `getFiles("knit.html")`) and to [tempdir()] in
+#'   ordinary R sessions, so the package never writes into your working
+#'   directory unless you ask it to. Set
+#'   `options(formr.in_opencpu = TRUE/FALSE)` to force either default.
 #' @param ... all other arguments passed to [rmarkdown::render()]
-#' 
+#'
 #' @return A length-1 character string: the path to the rendered HTML file.
 #' @export
 
-formr_render = function(text, self_contained = FALSE, ...) {
+formr_render = function(text, self_contained = FALSE, dir = NULL, ...) {
   fileName = rmarkdown::render(input = write_to_file(text,
-    name = "knit", ext = ".Rmd"), output_format = formr::markdown_hard_line_breaks(self_contained = self_contained,
+    name = "knit", ext = ".Rmd", dir = dir), output_format = formr::markdown_hard_line_breaks(self_contained = self_contained,
     fragment.only = FALSE), clean = TRUE, quiet = TRUE, ...)
   fileName
 }
 
 
+# Are we evaluating inside an OpenCPU request (i.e. on rforms.org)?
+#
+# Two signals, either suffices:
+# * The opencpu package evaluates every request in-process (forked children
+#   inherit loaded namespaces), so its namespace is loaded whenever code runs
+#   on an OpenCPU server -- but never in an ordinary user session.
+# * rforms.org populates the per-request `.formr` environment before user
+#   code runs, so any of its fields being set marks a formr study session.
+# `options(formr.in_opencpu = TRUE/FALSE)` overrides the detection.
+in_opencpu <- function() {
+  override <- getOption("formr.in_opencpu")
+  if (!is.null(override)) {
+    return(isTRUE(override))
+  }
+  if ("opencpu" %in% loadedNamespaces()) {
+    return(TRUE)
+  }
+  !is.null(.formr$host) || !is.null(.formr$run_name) ||
+    !is.null(.formr$access_token) || !is.null(.formr$last_action_time)
+}
 
-write_to_file <- function(..., name = NULL, ext = ".Rmd") {
+# Default directory for the named knit artifacts (knit.Rmd/knit.html).
+knit_dir <- function() {
+  if (in_opencpu()) getwd() else tempdir()
+}
+
+write_to_file <- function(..., name = NULL, ext = ".Rmd", dir = NULL) {
   if (is.null(name)) {
     filename <- paste0(tempfile(), ext)
   } else {
-    # A named write lands in the working directory on purpose: formr_render()
-    # passes name = "knit" so rmarkdown produces "knit.html" there, which is
-    # the file rforms.org/OpenCPU serves via getFiles("knit.html"). Moving this
-    # into tempdir() (v1.1.1) broke that lookup in production -- see issue #45's
-    # follow-up; do not "fix" it back to tempdir without updating the PHP side.
-    filename = paste0(name, ext)
+    # Named writes (formr_render()/formr_inline_render() pass name = "knit")
+    # must land in the OpenCPU session working directory when running on
+    # rforms.org: the server serves the rendered page via getFiles("knit.html"),
+    # and routing this through tempdir() (v1.1.1) broke that lookup in
+    # production -- see issue #45's follow-up. In ordinary user sessions that
+    # same write would violate CRAN policy, so knit_dir() picks getwd() only
+    # inside OpenCPU (see in_opencpu()) and tempdir() everywhere else.
+    if (is.null(dir)) {
+      dir <- knit_dir()
+    }
+    filename = file.path(dir, paste0(name, ext))
   }
   mytext <- eval(...)
   write(mytext, filename)

--- a/R/store_keys.R
+++ b/R/store_keys.R
@@ -49,9 +49,10 @@ formr_store_keys <- function(account_name = NULL,
 														 account = NULL,
 														 verbose = TRUE) {
 	
-	if (!requireNamespace("keyring", quietly = TRUE)) {
-		stop("Package 'keyring' is required. Install it with install.packages(\"keyring\").")
-	}
+	# Offers to install keyring on first use in interactive sessions;
+	# errors with an informative message otherwise.
+	rlang::check_installed("keyring",
+		reason = "to store credentials in your system keyring.")
 	
 	# --- LOGIC BRANCH 1: Classic MODE ---
 	# Triggered if the user provides a positional argument or explicitly sets account_name

--- a/R/store_keys.R
+++ b/R/store_keys.R
@@ -50,7 +50,7 @@ formr_store_keys <- function(account_name = NULL,
 														 verbose = TRUE) {
 	
 	if (!requireNamespace("keyring", quietly = TRUE)) {
-		stop("Package 'keyring' is required.")
+		stop("Package 'keyring' is required. Install it with install.packages(\"keyring\").")
 	}
 	
 	# --- LOGIC BRANCH 1: Classic MODE ---

--- a/man/formr_connect.Rd
+++ b/man/formr_connect.Rd
@@ -18,7 +18,11 @@ formr_connect(
 
 \item{host}{defaults to \code{\link[=formr_last_host]{formr_last_host()}}, which defaults to https://rforms.org}
 
-\item{keyring}{a shorthand for the account you're using}
+\item{keyring}{a shorthand for the account you're using. Requires the
+suggested \code{keyring} package; generating a 2FA code from a stored secret
+additionally requires the suggested \code{otp} package. Both are optional so
+that the package stays installable on platforms without a system
+credential store (e.g. WebAssembly/webR).}
 }
 \value{
 Invisibly \code{TRUE} on success; called for its side effect of establishing

--- a/man/formr_connect.Rd
+++ b/man/formr_connect.Rd
@@ -22,7 +22,8 @@ formr_connect(
 suggested \code{keyring} package; generating a 2FA code from a stored secret
 additionally requires the suggested \code{otp} package. Both are optional so
 that the package stays installable on platforms without a system
-credential store (e.g. WebAssembly/webR).}
+credential store (e.g. WebAssembly/webR); in interactive sessions you
+will be offered to install them the first time they are needed.}
 }
 \value{
 Invisibly \code{TRUE} on success; called for its side effect of establishing

--- a/man/formr_inline_render.Rd
+++ b/man/formr_inline_render.Rd
@@ -4,12 +4,17 @@
 \alias{formr_inline_render}
 \title{render inline text for formr}
 \usage{
-formr_inline_render(text, self_contained = TRUE, ...)
+formr_inline_render(text, self_contained = TRUE, dir = NULL, ...)
 }
 \arguments{
 \item{text}{that will be written to a tmp file and used as the input argument}
 
 \item{self_contained}{passed to \link{markdown_custom_options}}
+
+\item{dir}{directory in which the intermediate \code{knit.Rmd} and the rendered
+\code{knit.html} are written. Defaults to the working directory inside an
+OpenCPU/formr session and to \code{\link[=tempdir]{tempdir()}} in ordinary R sessions; see
+\code{\link[=formr_render]{formr_render()}} for details.}
 
 \item{...}{all other arguments passed to \code{\link[rmarkdown:render]{rmarkdown::render()}}}
 }

--- a/man/formr_render.Rd
+++ b/man/formr_render.Rd
@@ -4,12 +4,21 @@
 \alias{formr_render}
 \title{render text for formr}
 \usage{
-formr_render(text, self_contained = FALSE, ...)
+formr_render(text, self_contained = FALSE, dir = NULL, ...)
 }
 \arguments{
 \item{text}{that will be written to a tmp file and used as the input argument}
 
 \item{self_contained}{passed to \link{markdown_custom_options}}
+
+\item{dir}{directory in which the intermediate \code{knit.Rmd} and the rendered
+\code{knit.html} are written. Defaults to the working directory when the code
+runs inside an OpenCPU/formr session (there, the working directory is the
+ephemeral per-request session directory from which rforms.org retrieves
+the rendered page via \code{getFiles("knit.html")}) and to \code{\link[=tempdir]{tempdir()}} in
+ordinary R sessions, so the package never writes into your working
+directory unless you ask it to. Set
+\code{options(formr.in_opencpu = TRUE/FALSE)} to force either default.}
 
 \item{...}{all other arguments passed to \code{\link[rmarkdown:render]{rmarkdown::render()}}}
 }

--- a/tests/testthat/test-connect_to_formr.R
+++ b/tests/testthat/test-connect_to_formr.R
@@ -1,5 +1,4 @@
 library(testthat)
-library(keyring)
 library(httr)
 library(jsonlite)
 

--- a/tests/testthat/test-rmarkdown_options.R
+++ b/tests/testthat/test-rmarkdown_options.R
@@ -15,22 +15,79 @@ test_that("formr_render_commonmark works correctly", {
 })
 
 # Regression: rforms.org/OpenCPU serves the rendered page via
-# getFiles("knit.html"), so formr_render() must emit a file literally named
-# "knit.html" in the working directory. v1.1.1 moved this into tempdir() with a
-# random name and broke production rendering; this guards against a recurrence.
-test_that("formr_render writes knit.html to the working directory", {
+# getFiles("knit.html") from the session working directory, so inside an
+# OpenCPU/formr session (simulated here via the formr.in_opencpu option)
+# formr_render() must emit a file literally named "knit.html" in the working
+# directory. v1.1.1 moved this into tempdir() with a random name and broke
+# production rendering; this guards against a recurrence.
+test_that("formr_render writes knit.html to the working directory inside OpenCPU", {
   skip_if_not_installed("rmarkdown")
+  skip_if_not_installed("withr")
 
   wd <- file.path(tempdir(), "formr_render_wd")
   dir.create(wd, showWarnings = FALSE)
   old <- setwd(wd)
-  on.exit({ setwd(old); unlink(c("knit.Rmd", "knit.html", "knit_files"), recursive = TRUE) }, add = TRUE)
-  unlink(c("knit.Rmd", "knit.html"))
+  on.exit({ setwd(old); unlink(wd, recursive = TRUE) }, add = TRUE)
 
+  withr::local_options(formr.in_opencpu = TRUE)
   out <- formr_render("# Hi\n\nThere are `r 1 + 1` types.")
 
   expect_identical(basename(out), "knit.html")
   expect_true(file.exists(file.path(wd, "knit.html")))
+})
+
+# CRAN policy: in an ordinary R session the default must NOT touch the
+# working directory -- rendering goes through tempdir() instead.
+test_that("formr_render stays out of the working directory outside OpenCPU", {
+  skip_if_not_installed("rmarkdown")
+  skip_if_not_installed("withr")
+
+  wd <- file.path(tempdir(), "formr_render_local_wd")
+  dir.create(wd, showWarnings = FALSE)
+  old <- setwd(wd)
+  on.exit({ setwd(old); unlink(wd, recursive = TRUE) }, add = TRUE)
+
+  withr::local_options(formr.in_opencpu = FALSE)
+  out <- formr_render("# Hi\n\nThere are `r 1 + 1` types.")
+
+  expect_identical(basename(out), "knit.html")
+  expect_identical(normalizePath(dirname(out)), normalizePath(tempdir()))
+  expect_false(file.exists(file.path(wd, "knit.html")))
+  expect_false(file.exists(file.path(wd, "knit.Rmd")))
+})
+
+test_that("formr_render honours an explicit dir argument", {
+  skip_if_not_installed("rmarkdown")
+  skip_if_not_installed("withr")
+
+  out_dir <- file.path(tempdir(), "formr_render_explicit_dir")
+  dir.create(out_dir, showWarnings = FALSE)
+  on.exit(unlink(out_dir, recursive = TRUE), add = TRUE)
+
+  withr::local_options(formr.in_opencpu = FALSE)
+  out <- formr_render("Hi", dir = out_dir)
+
+  expect_identical(normalizePath(dirname(out)), normalizePath(out_dir))
+  expect_true(file.exists(file.path(out_dir, "knit.html")))
+})
+
+test_that("in_opencpu() detects the rforms.org per-request environment", {
+  skip_if_not_installed("withr")
+  skip_if("opencpu" %in% loadedNamespaces())
+
+  # the option override wins in both directions
+  withr::with_options(list(formr.in_opencpu = TRUE),
+                      expect_true(formr:::in_opencpu()))
+  withr::with_options(list(formr.in_opencpu = FALSE),
+                      expect_false(formr:::in_opencpu()))
+
+  # outside a formr session nothing is populated
+  expect_false(formr:::in_opencpu())
+
+  # rforms.org fills .formr before user code runs
+  .formr$host <- "https://api.rforms.org"
+  on.exit(.formr$host <- NULL, add = TRUE)
+  expect_true(formr:::in_opencpu())
 })
 
 test_that("paste.knit_asis works correctly", {

--- a/tests/testthat/test-store_keys.R
+++ b/tests/testthat/test-store_keys.R
@@ -95,18 +95,19 @@ test_that("formr_store_keys (Classic Mode) stores credentials correctly", {
 	expect_equal(stored_2fa, test_2fa)
 })
 
-test_that("formr_store_keys throws informative error if keyring is missing", {
+test_that("formr_store_keys checks for keyring before touching it", {
 	# This test requires the 'mockery' package to stub the environment
 	skip_if_not_installed("mockery")
-	
-	# 1. Setup the stub
-	# We tell R: "When 'formr_store_keys' calls 'requireNamespace', 
-	# make it return FALSE instead of actually checking the package."
-	mockery::stub(formr_store_keys, "requireNamespace", FALSE)
-	
-	# 2. Expect the specific error message
+
+	# Simulate the missing-package path: rlang::check_installed() throws (as
+	# it does when the user declines the install offer, or non-interactively)
+	# instead of consulting the real library.
+	mockery::stub(formr_store_keys, "rlang::check_installed",
+		function(pkg, ...) stop('The package "keyring" is required.'))
+
+	# The guard must fire before any keyring call
 	expect_error(
 		formr_store_keys(account_name = "dummy_account"),
-		"Package 'keyring' is required"
+		'"keyring" is required'
 	)
 })


### PR DESCRIPTION
Three changes for v1.1.3, all about making the package work across more platforms without breaking the rforms.org/OpenCPU integration.

## 1. Auto-detect OpenCPU to choose the `formr_render()` write directory

Since the 1.1.2 hotfix, `formr_render()` and `formr_inline_render()` unconditionally write `knit.Rmd`/`knit.html` into the working directory. rforms.org needs this — the server retrieves the rendered page from the OpenCPU session directory via `getFiles("knit.html")` — but in an ordinary user R session it violates CRAN policy. The 1.1.1 attempt to fix this by always using `tempdir()` broke production rendering.

The write directory is now chosen automatically, so the formr.org/PHP side needs no changes:

- New internal `in_opencpu()` detects an OpenCPU/formr session via two independent signals, either of which suffices:
  1. the `opencpu` namespace is loaded — true in any process evaluating an OpenCPU request, never in an ordinary user session;
  2. the per-request `.formr` environment is populated (`host`, `run_name`, `access_token`, or `last_action_time`) — rforms.org sets these before user code runs.
- Inside OpenCPU, files land in the session working directory, byte-for-byte the 1.1.2 behaviour (the OpenCPU working directory is itself an ephemeral per-request temp directory, so this is also CRAN-safe). Everywhere else they go to `tempdir()`, restoring CRAN compliance.
- Escape hatches: `options(formr.in_opencpu = TRUE/FALSE)` forces the detection either way, and both functions gain an explicit `dir` argument (`NULL` = auto).

## 2. Move `keyring` and `otp` from Imports to Suggests (WASM installability)

formr could not be installed in webR/WebAssembly. The blocker is `keyring`: it compiles against system credential stores (libsecret/DBus on Linux), which neither build nor make sense in a browser. `otp` is niche and only needed to generate TOTP codes for 2FA logins. Every remaining hard dependency is available as a wasm binary on repo.r-wasm.org (verified against the webR repo package list; `curl` is covered via the `httr` dependency chain).

Both packages only serve the credential-storage convenience path; behaviour with the packages installed is unchanged.

## 3. Offer to install suggested packages on first use

The guards in front of suggested packages (`keyring`, `otp`, `plotly`, `commonmark`) now use `rlang::check_installed()` instead of bare `requireNamespace()` + `stop()`. In interactive sessions the user is offered to install the missing package right when a function first needs it (via pak if available, falling back to `install.packages()`); non-interactive sessions get an informative classed error. rlang was already an Import and is now pinned to >= 1.0.0.

Details:
- The `otp` check in `formr_connect()` deliberately does not abort — if the user declines the install offer (or the session is non-interactive), they can still enter the 2FA code manually.
- The silent fallback chains (keyring lookup in `formr_api_authenticate()`, rstudioapi detection in the project sync) keep their quiet `requireNamespace()` checks, since prompting there would interrupt a fallback rather than a user-requested feature.

## Tests

- OpenCPU-session regression test now simulates the server context and asserts `knit.html` lands in the working directory; new tests assert the local default stays out of the working directory (goes to `tempdir()`), the explicit `dir` works, and `in_opencpu()` responds to the option override and to a populated `.formr`.
- Verified the wasm scenario end-to-end: installed and loaded formr with `keyring`/`otp` hidden from the library path — clean load, and the guarded paths raise the informative `check_installed()` errors non-interactively.
- The keyring-missing unit test now stubs `rlang::check_installed` and asserts the guard fires before any keyring call.
- All affected test files pass. Full suite: only the 12 pre-existing `test-api_integration.R` live-API errors remain (identical on the unmodified tree in this container — no credentials/cassette replay).

⚠️ Note: `man/` was regenerated with roxygen2 7.3.1 (the version available in the dev container) instead of the 8.0.0 recorded in `DESCRIPTION`; unrelated Rd churn was reverted, but you may want to re-run `devtools::document()` locally before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019AdUYJFK8FUhtiAoMzrvEz